### PR TITLE
Remove regions not yet supported

### DIFF
--- a/.taskcat.yml
+++ b/.taskcat.yml
@@ -15,30 +15,10 @@ project:
     IamPassword: $[taskcat_genpass_128S]
     IamGroupName: $[taskcat_genpass_8A]
   regions:
-    - af-south-1
-    - ap-east-1
-    - ap-northeast-1
-    - ap-northeast-2
-    - ap-south-1
     - ap-southeast-1
-    - ap-southeast-2
-    - ca-central-1
     - eu-central-1
-    - eu-north-1
-    - eu-west-1
-    - eu-west-2
-    - eu-west-3
-    - me-south-1
-    - sa-east-1
     - us-east-1
-    - us-east-2
-    - us-west-1
     - us-west-2
-    - us-gov-west-1
-  # regions-not-yet-supported:
-  # # One or more required services aren't available yet in these regions
-  #   - ap-northeast-3
-  #   - ap-southeast-3
 tests:
   default:
     regions:


### PR DESCRIPTION
Chime SDK Media Pipeline Control plane dependency: https://docs.aws.amazon.com/chime-sdk/latest/dg/sdk-available-regions.html#sdk-media-pipelines

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
